### PR TITLE
Fix bug with early return

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8080
+
 AWS_KEY=abcde
 DB=user@foobar.com/corge

--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ function apply () {
   var row;
 
   while (++i < len) {
-    if (!doc[i]) return;
+    if (!doc[i]) continue;
     row = doc[i].split(/\s*=\s*/);
 
-    if (process.env[row[0]] != undefined) return;
+    if (process.env[row[0]] != undefined) continue;
 
     process.env[row[0]] = row[1];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-env",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Read and apply .env file if exists in the working directory",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If the environment already had a value, it was returning instead of continuing on to the next key-value.
