### PR TITLE
Fix quoted env params and urls with query string params.

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ PORT=8080
 
 AWS_KEY=abcde
 DB=user@foobar.com/corge
+DBSET=mongodb://user:pass@foobar.com:4000,barfoo.com:5000/corge?replicaSet=rs-ds012345
+DQUOTE="this is quoted"
+SQUOTE='this is also quoted'

--- a/index.js
+++ b/index.js
@@ -18,6 +18,6 @@ function apply () {
   while (++i < len) {
     if (!doc[i]) continue;
     row = doc[i].split(/\s*=\s*/);
-    process.env[row.shift()] = row.join('').replace(/['"]/,'');
+    process.env[row.shift()] = row.join('=').replace(/['"]/g,'');
   }
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,6 @@ function apply () {
   while (++i < len) {
     if (!doc[i]) continue;
     row = doc[i].split(/\s*=\s*/);
-    process.env[row[0]] = row[1];
+    process.env[row.shift()] = row.join('');
   }
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,6 @@ function apply () {
   while (++i < len) {
     if (!doc[i]) continue;
     row = doc[i].split(/\s*=\s*/);
-    process.env[row.shift()] = row.join('');
+    process.env[row.shift()] = row.join('').replace(/['"]/,'');
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,8 +3,11 @@ require('./')();
 var test = require("prova");
 
 test('applies .env to process.env', function (assert) {
-  assert.plan(3);
+  assert.plan(6);
   assert.equal(process.env.PORT, '8080');
   assert.equal(process.env.AWS_KEY, 'abcde');
   assert.equal(process.env.DB, 'user@foobar.com/corge');
+  assert.equal(process.env.DBSET, 'mongodb://user:pass@foobar.com:4000,barfoo.com:5000/corge?replicaSet=rs-ds012345');
+  assert.equal(process.env.DQUOTE, 'this is quoted');
+  assert.equal(process.env.SQUOTE, 'this is also quoted');
 });


### PR DESCRIPTION
This fixes env vars with params that are in quotes (as outputted by heroku config:pull) such as 
```
NODE_ENV="development"
```

And fixes URLs that have query string params, such as
```
MONGOLAB_URI="mongodb://......heroku_k1234567?replicaSet=rs-ds01234567"
```